### PR TITLE
Clear up confusion with how Commit::message() should work

### DIFF
--- a/src/Bart/Git/Commit.php
+++ b/src/Bart/Git/Commit.php
@@ -43,10 +43,21 @@ class Commit
 		return $this->revision;
 	}
 
+	public function messageBody()
+	{
+		$result = $this->gitRoot->getCommandResult('show -s --pretty=%s --no-color %s', 'format:%B', $this->revision);
+
+		if (!$result->wasOk()) {
+			throw new GitException("Could not get contents of commit {$this}");
+		}
+
+		return $result->getOutput(true);
+	}
+
 	/**
-	 * @return string The basic commit log message
+	 * @return string The full commit log message
 	 */
-	public function message()
+	public function messageFull()
 	{
 		$result = $this->gitRoot->getCommandResult('show -s --format=full --no-color %s', $this->revision);
 
@@ -58,12 +69,20 @@ class Commit
 	}
 
 	/**
+	 * @deprecated {@see self::messageFull()}
+	 */
+	public function message()
+	{
+		return $this->messageFull();
+	}
+
+	/**
 	 * @return string Gerrit Change-Id
 	 * @throws GitException if no Change-Id in message
 	 */
 	public function gerritChangeId()
 	{
-		$message = $this->message();
+		$message = $this->messageFull();
 
 		$matches = array();
 		preg_match("/.*Change-Id: ([Ia-z0-9]*)/", $message, $matches);
@@ -99,7 +118,7 @@ class Commit
 		if ($this->_jiras === null) {
 			$this->_jiras = [];
 
-			$message = $this->message();
+			$message = $this->messageFull();
 
 			$matches = [];
 			if (preg_match_all('/([A-Z]{1,8}-[1-9]?[0-9]*)/', $message, $matches) > 0) {

--- a/src/Bart/Git/Commit.php
+++ b/src/Bart/Git/Commit.php
@@ -43,6 +43,10 @@ class Commit
 		return $this->revision;
 	}
 
+	/**
+	 * @return string The body of the commit message (just the log message, not the author, etc.)
+	 * @throws GitException
+	 */
 	public function messageBody()
 	{
 		$result = $this->gitRoot->getCommandResult('show -s --pretty=%s --no-color %s', 'format:%B', $this->revision);

--- a/src/Bart/GitHook/GitHookController.php
+++ b/src/Bart/GitHook/GitHookController.php
@@ -161,7 +161,7 @@ class GitHookController
 	 */
 	private function shouldSkip(Commit $commit, GitHookConfig $gitHookConfig)
 	{
-		$message = $commit->message();
+		$message = $commit->messageBody();
 
 		$isEmergency = preg_match('/^EMERGENCY/', $message) === 1;
 

--- a/src/Bart/GitHook/GitHookRunner.php
+++ b/src/Bart/GitHook/GitHookRunner.php
@@ -79,7 +79,7 @@ abstract class GitHookRunner
 					throw $e;
 				}
 				else {
-					$this->logger->warn("The GitHook $actionName did not halt on failure but also did run successfully. Continuing other hooks.");
+					$this->logger->warn("The GitHook $actionName did not halt on failure but didn't run successfully. Continuing other hooks.", $e);
 				}
 			}
 		}

--- a/test/Bart/GitHook/GitHookControllerTest.php
+++ b/test/Bart/GitHook/GitHookControllerTest.php
@@ -143,7 +143,7 @@ class GitHookControllerTest extends BaseTestCase
 		$numInputs = count($stdInArray);
 		$numRevs = count($revList);
 
-		$message = $emergency ? 'EMERGENCY commit' : "This message will be ignored";
+		$message = $emergency ? "EMERGENCY commit" : "This message will be ignored";
 
 		$this->shmockAndDieselify('\Bart\Shell', function($shell) use($stdInArray) {
 			$shell->realpath(self::POST_RECEIVE_PATH)->once()->return_value(self::POST_RECEIVE_REAL_PATH);
@@ -187,7 +187,7 @@ class GitHookControllerTest extends BaseTestCase
 		// The number of runs for $gitCommit->message() and $postReceiveRunner->runAllActions depend on $numValidRefs
 		$numValidCommits = $numValidRefs * $numRevs;
 		$stubCommit = $this->shmockAndDieselify('\Bart\Git\Commit', function($gitCommit) use($numValidCommits, $message) {
-			$gitCommit->message()->times($numValidCommits)->return_value($message);
+			$gitCommit->messageBody()->times($numValidCommits)->return_value($message);
 		}, true);
 
 		if ($emergency) {

--- a/test/Bart/Shell/CommandResultTest.php
+++ b/test/Bart/Shell/CommandResultTest.php
@@ -25,34 +25,3 @@ class CommandResultTest extends BaseTestCase
 	}
 }
 
-/**
- * For stubbing results of Command::getResult()
- */
-class StubbedCommandResult extends CommandResult
-{
-	/** @var Command */
-	private static $_echoCmd;
-
-	/**
-	 * Create a stub of a command result for testing
-	 * @param array $output The output of exec
-	 * @param int $statusCode The shell return status
-	 */
-	public function __construct($output, $statusCode)
-	{
-		parent::__construct(self::echoCmd(), $output, $statusCode);
-	}
-
-	/**
-	 * @return Command Just re-use this dummy command each time
-	 */
-	private static function echoCmd()
-	{
-		if (!self::$_echoCmd) {
-			self::$_echoCmd = new Command('echo');
-		}
-
-		return self::$_echoCmd;
-	}
-}
- 

--- a/test/Bart/Shell/StubbedCommandResult.php
+++ b/test/Bart/Shell/StubbedCommandResult.php
@@ -1,0 +1,34 @@
+<?php
+namespace Bart\Shell;
+
+/**
+ * For stubbing results of Command::getResult()
+ */
+class StubbedCommandResult extends CommandResult
+{
+	/** @var Command */
+	private static $_echoCmd;
+
+	/**
+	 * Create a stub of a command result for testing
+	 * @param array $output The output of exec
+	 * @param int $statusCode The shell return status
+	 */
+	public function __construct($output, $statusCode)
+	{
+		parent::__construct(self::echoCmd(), $output, $statusCode);
+	}
+
+	/**
+	 * @return Command Just re-use this dummy command each time
+	 */
+	private static function echoCmd()
+	{
+		if (!self::$_echoCmd) {
+			self::$_echoCmd = new Command('echo');
+		}
+
+		return self::$_echoCmd;
+	}
+}
+


### PR DESCRIPTION
Per #26, emergency commits were not being skipped because the `message()` method
was returning other commit metadata prior to the message body

This commit adds a new method to extract *only* the message body