### PR TITLE
Modify Diesel to support TestScribe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
   "require": {
     "php": ">=5.4.0",
     "chobie/jira-api-restclient": "2.0.*@dev",
-    "apache/log4php": "2.3.0"
+    "apache/log4php": "2.3.0",
+    "phpoption/phpoption": "^1.5"
   },
   "require-dev": {
     "phpunit/phpunit": "3.7.*",
@@ -30,4 +31,3 @@
     }
   }
 }
-

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,11 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ed3cc3685190a582e99fa4543415410a",
+    "hash": "6d3a1b79f7b47939faadccd4331221a8",
+    "content-hash": "baf65b54fda71d60ea8b05dba83a95d9",
     "packages": [
         {
             "name": "apache/log4php",
@@ -85,6 +86,56 @@
                 "rest"
             ],
             "time": "2014-07-27 11:55:20"
+        },
+        {
+            "name": "phpoption/phpoption",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/php-option.git",
+                "reference": "94e644f7d2051a5f0fcf77d81605f152eecff0ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/94e644f7d2051a5f0fcf77d81605f152eecff0ed",
+                "reference": "94e644f7d2051a5f0fcf77d81605f152eecff0ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.7.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PhpOption\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Option Type for PHP",
+            "keywords": [
+                "language",
+                "option",
+                "php",
+                "type"
+            ],
+            "time": "2015-07-25 16:39:46"
         }
     ],
     "packages-dev": [
@@ -564,6 +615,7 @@
         "chobie/jira-api-restclient": 20
     },
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.4.0"
     },

--- a/src/Bart/Diesel.php
+++ b/src/Bart/Diesel.php
@@ -9,6 +9,8 @@ namespace Bart;
  */
 class Diesel
 {
+	private static $isTestGeneratorRun = null;
+
 	/**
 	 * @var array Registry of all instantiation methods
 	 */
@@ -33,6 +35,11 @@ class Diesel
 		$arguments = func_get_args();
 		$className = array_shift($arguments);
 
+		$mockObj = self::checkTestScribe($className, $arguments);
+		if ($mockObj !== null) {
+			return $mockObj;
+		}
+
 		// If a method has been registered
 		if (array_key_exists($className, self::$instantiators)) {
 			$instantiator = self::$instantiators[$className];
@@ -41,6 +48,46 @@ class Diesel
 		}
 
 		return self::createInstance($className, $arguments);
+	}
+
+	/**
+	 * Return true when PHPUnit test generator is loaded.
+	 * See comments in __callStatic method for more details.
+	 *
+	 * @return bool
+	 */
+	private static function isTestGeneratorRun()
+	{
+		if (self::$isTestGeneratorRun !== null) {
+			// Cache the result of this run time check
+			// to improve performance since resolve is called many times
+			// at run time.
+			return self::$isTestGeneratorRun;
+		}
+
+		// The test generator should have loaded the class and no autoloader should be needed
+		// when the class exists.
+		self::$isTestGeneratorRun = class_exists('\Box\TestScribe\App', false);
+
+		return self::$isTestGeneratorRun;
+	}
+
+	/**
+	 * Replace real instance with the given instance typically a mock object.
+	 *
+	 * @param string $className
+	 * @param object $instance
+	 *
+	 * @return void
+	 */
+	public static function overwrite($className, $instance)
+	{
+		self::registerInstantiator(
+			$className,
+			function () use ($instance) {
+				return $instance;
+			}
+		);
 	}
 
 	/**
@@ -124,6 +171,37 @@ class Diesel
 	public static function disableDefault()
 	{
 		self::$allowDefaults = false;
+	}
+
+
+	private static function checkTestScribe($className, $arguments)
+	{
+
+		/** @noinspection PhpUndefinedNamespaceInspection */
+		/** @noinspection PhpUndefinedClassInspection */
+		if (self::isTestGeneratorRun()
+			&& \Box\TestScribe\App::$shouldInjectMockObjects
+		) {
+			// This code block is to support PHPUnit test generator.
+			// @see https://github.com/box/TestScribe
+			// The class 'Box\TestScribe\App' should only be loaded
+			// when this method is executed by the test generator.
+			// It allows the test generator to substitute the real class instance with a
+			// mock object controlled by the test generator so that the test
+			// generator can monitor the creation and execution of the class
+			// being resolved.
+			/** @noinspection PhpUndefinedNamespaceInspection */
+			$mock = \Box\TestScribe\App::createMockedInstance(
+				$className,
+				$arguments
+			);
+			if ($mock) {
+				return $mock;
+			}
+			// If null is returned by the unit test generator,
+			// it means that the developer has decided not to mock this class.
+			// Proceed with creating the real object.
+		}
 	}
 }
 


### PR DESCRIPTION
This change paves the way for automatically generating unit tests in Bart-dependent projects, using https://github.com/box/TestScribe.