### PR TITLE
Git message subject

### DIFF
--- a/src/Bart/Git/Commit.php
+++ b/src/Bart/Git/Commit.php
@@ -44,12 +44,29 @@ class Commit
 	}
 
 	/**
-	 * @return string The body of the commit message (just the log message, not the author, etc.)
+	 * @return string The first non-blank lines of the commit message
 	 * @throws GitException
 	 */
-	public function messageBody()
+	public function messageSubject()
 	{
-		$result = $this->gitRoot->getCommandResult('show -s --pretty=%s --no-color %s', 'format:%B', $this->revision);
+		// Ironic we're replacing %s with %s
+		$result = $this->gitRoot->getCommandResult('show -s --format=%s --no-color %s', '%s', $this->revision);
+
+		if (!$result->wasOk()) {
+			throw new GitException("Could not get contents of commit {$this}");
+		}
+
+		return $result->getOutput(true);
+	}
+
+	/**
+	 * @requires Git 1.7.2
+	 * @return string The unwrapped subject and body of the commit message (just the log message, not the author, etc.)
+	 * @throws GitException
+	 */
+	public function messageRawBody()
+	{
+		$result = $this->gitRoot->getCommandResult('show -s --format=%s --no-color %s', '%B', $this->revision);
 
 		if (!$result->wasOk()) {
 			throw new GitException("Could not get contents of commit {$this}");

--- a/src/Bart/GitHook/GitHookController.php
+++ b/src/Bart/GitHook/GitHookController.php
@@ -161,7 +161,7 @@ class GitHookController
 	 */
 	private function shouldSkip(Commit $commit, GitHookConfig $gitHookConfig)
 	{
-		$message = $commit->messageBody();
+		$message = $commit->messageSubject();
 
 		$isEmergency = preg_match('/^EMERGENCY/', $message) === 1;
 

--- a/test/Bart/Git/CommitTest.php
+++ b/test/Bart/Git/CommitTest.php
@@ -31,7 +31,7 @@ $message";
 		});
 	}
 
-	public function testMessageBody()
+	public function testMessageRawBody()
 	{
 		$this->gitRoot = $this->shmock('\Bart\Git\GitRoot', function($root) {
 			$output = 'TOP-338 run unit tests when Nate or Zack commit code
@@ -39,14 +39,14 @@ $message";
 Change-Id: Iecb840ccccf70a79ae622c583761107aa1a1b7b9';
 			$resultStub = new StubbedCommandResult([$output], 0);
 
-			$root->getCommandResult('show -s --pretty=%s --no-color %s', 'format:%B', 'HEAD')
+			$root->getCommandResult('show -s --format=%s --no-color %s', '%B', 'HEAD')
 				->once()
 				->return_value($resultStub);
 		});
 		$commit = new Commit($this->gitRoot, 'HEAD');
 
 		// Assert all lines of log message are included
-		$message = $commit->messageBody();
+		$message = $commit->messageRawBody();
 		$this->assertStringStartsWith('TOP-338', $message, 'No escape args silliness with quotes');
 		$this->assertContains('TOP-338 run unit', $message, 'line one');
 		$this->assertContains('Iecb840ccccf70a79ae622c583761107aa1a1b7b9', $message, 'line two');

--- a/test/Bart/Git/CommitTest.php
+++ b/test/Bart/Git/CommitTest.php
@@ -31,6 +31,25 @@ $message";
 		});
 	}
 
+	public function testMessageSubject()
+	{
+		// This test is pretty much a "it compiles" test
+		$this->gitRoot = $this->shmock('\Bart\Git\GitRoot', function($root) {
+			$output = 'TOP-338 run unit tests when Nate or Zack commit code';
+			$resultStub = new StubbedCommandResult([$output], 0);
+
+			$root->getCommandResult('show -s --format=%s --no-color %s', '%s', 'HEAD')
+				->once()
+				->return_value($resultStub);
+		});
+		$commit = new Commit($this->gitRoot, 'HEAD');
+
+		// Assert all lines of log message are included
+		$message = $commit->messageSubject();
+		$this->assertStringStartsWith('TOP-338', $message, 'No escape args silliness with quotes');
+		$this->assertEquals('TOP-338 run unit tests when Nate or Zack commit code', $message, 'line one and only line one');
+	}
+
 	public function testMessageRawBody()
 	{
 		$this->gitRoot = $this->shmock('\Bart\Git\GitRoot', function($root) {

--- a/test/Bart/GitHook/GitHookControllerTest.php
+++ b/test/Bart/GitHook/GitHookControllerTest.php
@@ -187,7 +187,7 @@ class GitHookControllerTest extends BaseTestCase
 		// The number of runs for $gitCommit->message() and $postReceiveRunner->runAllActions depend on $numValidRefs
 		$numValidCommits = $numValidRefs * $numRevs;
 		$stubCommit = $this->shmockAndDieselify('\Bart\Git\Commit', function($gitCommit) use($numValidCommits, $message) {
-			$gitCommit->messageBody()->times($numValidCommits)->return_value($message);
+			$gitCommit->messageSubject()->times($numValidCommits)->return_value($message);
 		}, true);
 
 		if ($emergency) {


### PR DESCRIPTION
This will fix the issue with not matching `EMERGENCY` in commit messages on servers with older versions of git.

CC @nadeemahmad Thoughts? 