### PR TITLE
Make Jenkins Job class more flexible

### DIFF
--- a/src/Bart/Jenkins/Connection.php
+++ b/src/Bart/Jenkins/Connection.php
@@ -1,5 +1,6 @@
 <?php
 namespace Bart\Jenkins;
+
 use Bart\Diesel;
 use Bart\JSON;
 use Bart\Log4PHP;
@@ -16,7 +17,7 @@ class Connection
     /** @var \Logger */
     private $logger;
     /** @var array $curlOptions */
-	private $curlOptions;
+    private $curlOptions;
     /** @var int $port */
     private $port;
     /** @var string $baseUrl */
@@ -97,12 +98,10 @@ class Connection
 
         $httpCode = $response['info']['http_code'];
         $content = $response['content'];
-        if ($httpCode !== 200 && $httpCode !== 201 && $httpCode !== 202 ) {
+        if ($httpCode !== 200 && $httpCode !== 201 && $httpCode !== 202) {
             throw new JenkinsApiException("The Jenkins API call returned a {$httpCode}, " .
                 "with the following content: {$content}");
         }
-
-        $content = $response['content'];
         return JSON::decode($content);
     }
 }

--- a/src/Bart/Jenkins/Connection.php
+++ b/src/Bart/Jenkins/Connection.php
@@ -7,6 +7,7 @@ use Bart\Primitives\Strings;
 
 /**
  * Class Connection
+ * Manages interface between remote Jenkins REST API and client code
  * @package Bart\Jenkins
  */
 class Connection
@@ -72,7 +73,7 @@ class Connection
      * simple GET against the Jenkins Job 'Example', the full path, 'job/Example/api/json'
      * must be passed in.
      * @param array $postData if null, then curl uses GET, otherwise POSTs data
-     * @returns array JSON data decoded as PHP array
+     * @return array JSON data decoded as PHP array
      * @throws JenkinsApiException
      */
     public function curlJenkinsApi($apiPath, array $postData = null)
@@ -86,7 +87,7 @@ class Connection
         $this->logger->debug('Curling ' . ($isPost ? 'POST ' : 'GET ') . $fullUrl);
 
         /** @var \Bart\Curl $curl */
-        $curl = Diesel::create('Bart\Curl', $fullUrl, $this->port);
+        $curl = Diesel::create('\Bart\Curl', $fullUrl, $this->port);
         if ($this->curlOptions !== []) {
             $curl->setPhpCurlOpts($this->curlOptions);
         }

--- a/src/Bart/Jenkins/Connection.php
+++ b/src/Bart/Jenkins/Connection.php
@@ -1,0 +1,107 @@
+<?php
+namespace Bart\Jenkins;
+use Bart\Diesel;
+use Bart\JSON;
+use Bart\Log4PHP;
+use Bart\Primitives\Strings;
+
+/**
+ * Class Connection
+ * @package Bart\Jenkins
+ */
+class Connection
+{
+
+    /** @var \Logger */
+    private $logger;
+    /** @var array $curlOptions */
+	private $curlOptions;
+    /** @var int $port */
+    private $port;
+    /** @var string $baseUrl */
+    private $baseUrl;
+
+    /**
+     * Connection constructor.
+     * @param string $domain
+     * @param string $protocol 'http' or 'https'.
+     * @param int $port The port can be generally be determined by the $protocol. 'http' corresponds
+     * to port 8080, while 'https' corresponds to 443. If the $port is passed in, it will override
+     * that determination.
+     */
+    public function __construct($domain, $protocol = 'http', $port = null)
+    {
+        if (!in_array($protocol, ['http', 'https'])) {
+            throw new \InvalidArgumentException("The protocol must only be 'http' or 'https'");
+        }
+
+        $this->logger = Log4PHP::getLogger(__CLASS__);
+        $this->curlOptions = [];
+        $this->port = $port;
+        if ($this->port === null) {
+            if ($protocol === 'http') {
+                $this->port = 8080;
+            } else {
+                $this->port = 443;
+            }
+        }
+
+        $this->baseUrl = "{$protocol}://{$domain}:{$this->port}";
+        $this->logger->debug('Base URL: ' . $this->baseUrl);
+    }
+
+    /**
+     * Set Jenkins authentication
+     * NOTE: Authentication must be set if the Jenkins instance doesn't allow
+     * anonymous connections.
+     * @param string $user User to authenticate against.
+     * @param string $token API token corresponding to user.
+     */
+    public function setAuth($user, $token)
+    {
+        $this->curlOptions[CURLOPT_USERPWD] = "{$user}:{$token}";
+    }
+
+    /**
+     * Curl Jenkins JSON API
+     *
+     * NOTE: This method is not meant to be used on its own. It is used by other classes,
+     * e.g. \Bart\Jenkins\Job, to make API calls against Jenkins.
+     *
+     * @param string $apiPath The full API path to curl against. For example, to do a
+     * simple GET against the Jenkins Job 'Example', the full path, 'job/Example/api/json'
+     * must be passed in.
+     * @param array $postData if null, then curl uses GET, otherwise POSTs data
+     * @returns array JSON data decoded as PHP array
+     * @throws JenkinsApiException
+     */
+    public function curlJenkinsApi($apiPath, array $postData = null)
+    {
+        if (!Strings::startsWith($apiPath, '/')) {
+            $apiPath = "/{$apiPath}";
+        }
+
+        $fullUrl = "{$this->baseUrl}{$apiPath}";
+        $isPost = ($postData !== null);
+        $this->logger->debug('Curling ' . ($isPost ? 'POST ' : 'GET ') . $fullUrl);
+
+        /** @var \Bart\Curl $curl */
+        $curl = Diesel::create('Bart\Curl', $fullUrl, $this->port);
+        if ($this->curlOptions !== []) {
+            $curl->setPhpCurlOpts($this->curlOptions);
+        }
+        $response = $isPost ?
+            $curl->post('', [], $postData) :
+            $curl->get('', []);
+
+        $httpCode = $response['info']['http_code'];
+        $content = $response['content'];
+        if ($httpCode !== 200 && $httpCode !== 201 && $httpCode !== 202 ) {
+            throw new JenkinsApiException("The Jenkins API call returned a {$httpCode}, " .
+                "with the following content: {$content}");
+        }
+
+        $content = $response['content'];
+        return JSON::decode($content);
+    }
+}

--- a/src/Bart/Jenkins/JenkinsApiException.php
+++ b/src/Bart/Jenkins/JenkinsApiException.php
@@ -1,0 +1,9 @@
+<?php
+namespace Bart\Jenkins;
+
+/**
+ * Exceptions dealing with calls to the Jenkins REST API
+ */
+class JenkinsApiException extends \Exception
+{
+}

--- a/src/Bart/Jenkins/JenkinsApiException.php
+++ b/src/Bart/Jenkins/JenkinsApiException.php
@@ -6,4 +6,5 @@ namespace Bart\Jenkins;
  */
 class JenkinsApiException extends \Exception
 {
+
 }

--- a/src/Bart/Jenkins/Job.php
+++ b/src/Bart/Jenkins/Job.php
@@ -9,7 +9,7 @@ use Bart\Log4PHP;
 class Job
 {
 	private $defaultParams = [];
-	private $myBuildData;
+	private $myBuildId;
 	private $metadata;
 	/** @var \Logger */
 	private $logger;
@@ -115,8 +115,8 @@ class Job
 		if ($metadata['inQueue'] > 0)
 		{
 			// Build is queued, but must wait and hasn't been assigned a number
-			$this->myBuildData = $metadata['nextBuildNumber'];
-			$this->logger->debug('Queued build: ' . $this->myBuildData);
+			$this->myBuildId = $metadata['nextBuildNumber'];
+			$this->logger->debug('Queued build: ' . $this->myBuildId);
 
 			// @TODO Sleep until build should be running?
 			// sleep($metadata['queueItem']['buildableStartMilliseconds']);
@@ -125,16 +125,16 @@ class Job
 		{
 			// If no builds blocking (system wide), this build starts right away
 			// ...and has been assigned a build number
-			$this->myBuildData = $this->last_build_id(false);
-			$this->logger->debug('Started build: ' . $this->myBuildData);
+			$this->myBuildId = $this->last_build_id(false);
+			$this->logger->debug('Started build: ' . $this->myBuildId);
 		}
 
-		if ($last_completed_build_id == $this->myBuildData)
+		if ($last_completed_build_id == $this->myBuildId)
 		{
 			throw new \Exception('Could not create new jenkins job. Quitting.');
 		}
 
-		return $this->myBuildData;
+		return $this->myBuildId;
 	}
 
 	/**
@@ -155,7 +155,7 @@ class Job
 	 */
 	public function query_status()
 	{
-		$job_data = $this->getJson(array("{$this->myBuildData}"));
+		$job_data = $this->getJson(array("{$this->myBuildId}"));
 
 		return $job_data['result'];
 	}
@@ -170,7 +170,7 @@ class Job
 		// Poll jenkins until last build number is our build number or greater
 		$last_completed_build_id = $this->last_build_id(true);
 		$started = time();
-		while ($last_completed_build_id < $this->myBuildData
+		while ($last_completed_build_id < $this->myBuildId
 			&& time() < (60 * $timeout_after) + $started)
 		{
 			sleep($poll_period);

--- a/src/Bart/Jenkins/Job.php
+++ b/src/Bart/Jenkins/Job.php
@@ -9,261 +9,260 @@ use Bart\Primitives\Strings;
  */
 class Job
 {
-	private $defaultParams = [];
-	private $myBuildId;
-	private $metadata;
-	/** @var \Logger */
-	private $logger;
+    private $defaultParams = [];
+    private $myBuildId;
+    private $metadata;
+    /** @var \Logger */
+    private $logger;
 
-	/** @var Connection $connection */
-	private $connection;
-	/** @var string $baseApiPath */
-	private $baseApiPath;
+    /** @var Connection $connection */
+    private $connection;
+    /** @var string $baseApiPath */
+    private $baseApiPath;
 
-	/**
-	 * Job constructor. Loads metadata about a project.
-	 * @param Connection $connection
-	 * @param string $projectPath This parameter specifies the location of the Jenkins Job.
-	 * For example, if your Job is defined in the following third level project: Base->Build->Example,
-	 * you must pass in the full path to the project, 'job/Base/job/Build/job/Example'.
+    /**
+     * Job constructor. Loads metadata about a project.
+     * @param Connection $connection
+     * @param string $projectPath This parameter specifies the location of the Jenkins Job.
+     * For example, if your Job is defined in the following third level project: Base->Build->Example,
+     * you must pass in the full path to the project, 'job/Base/job/Build/job/Example'.
      */
-	public function __construct(Connection $connection, $projectPath)
-	{
-		if (!is_string($projectPath)) {
-			throw new \InvalidArgumentException('The projectPath must be of type string');
-		}
-		$this->connection = $connection;
-		$this->logger = Log4PHP::getLogger(__CLASS__);
+    public function __construct(Connection $connection, $projectPath)
+    {
+        if (!is_string($projectPath)) {
+            throw new \InvalidArgumentException('The projectPath must be of type string');
+        }
+        $this->connection = $connection;
+        $this->logger = Log4PHP::getLogger(__CLASS__);
 
-		if (!Strings::startsWith($projectPath, '/')) {
-			$projectPath = "/{$projectPath}";
-		}
+        if (!Strings::startsWith($projectPath, '/')) {
+            $projectPath = "/{$projectPath}";
+        }
 
-		if (Strings::endsWith($projectPath, '/')) {
-			$projectPath = substr($projectPath, 0, strlen($projectPath) - 1);
-		}
+        if (Strings::endsWith($projectPath, '/')) {
+            $projectPath = substr($projectPath, 0, strlen($projectPath) - 1);
+        }
 
-		$projects = explode('/job/', $projectPath);
-		unset($projects[0]);
+        $projects = explode('/job/', $projectPath);
+        unset($projects[0]);
 
-		$this->baseApiPath = '/';
-		foreach($projects as $project) {
-			$projectEncoded = rawurlencode($project);
-			$this->baseApiPath .= "job/{$projectEncoded}/";
-		}
-		$this->metadata = $this->getJson(array());
+        $this->baseApiPath = '/';
+        foreach ($projects as $project) {
+            $projectEncoded = rawurlencode($project);
+            $this->baseApiPath .= "job/{$projectEncoded}/";
+        }
+        $this->metadata = $this->getJson(array());
 
-		if (!isset($this->metadata['buildable'])) {
-			throw new \InvalidArgumentException("The project at path '{$this->baseApiPath}'' is disabled");
-		}
-		$this->setDefaultParameters();
-	}
+        if (!isset($this->metadata['buildable'])) {
+            throw new \InvalidArgumentException("The project at path '{$this->baseApiPath}'' is disabled");
+        }
+        $this->setDefaultParameters();
+    }
 
-	/**
-	 * Load the default set of parameters defined by project
-	 */
-	private function setDefaultParameters()
-	{
-		$properties = $this->metadata['property'];
-		if (count($properties) == 0) return;
+    /**
+     * Load the default set of parameters defined by project
+     */
+    private function setDefaultParameters()
+    {
+        $properties = $this->metadata['property'];
+        if (count($properties) == 0) return;
 
-		// To determine the default parameters, we need to figure out which of sub-arrays
-		// actually contains the 'parameterDefinitions'.
-		$params = null;
-		for ($i = 0; $i < count($properties); $i++) {
-			if (isset($properties[$i]['parameterDefinitions'])) {
-				$params = (array) $properties[$i]['parameterDefinitions'];
-				break;
-			}
-		}
+        // To determine the default parameters, we need to figure out which of sub-arrays
+        // actually contains the 'parameterDefinitions'.
+        $params = null;
+        for ($i = 0; $i < count($properties); $i++) {
+            if (isset($properties[$i]['parameterDefinitions'])) {
+                $params = (array)$properties[$i]['parameterDefinitions'];
+                break;
+            }
+        }
 
-		if ($params === null) {
-			throw new \InvalidArgumentException("The parameterDefinitions are not part of the data.");
-		}
+        if ($params === null) {
+            throw new \InvalidArgumentException("The parameterDefinitions are not part of the data.");
+        }
 
-		foreach ($params as $p => $param) {
-			$default = $param['defaultParameterValue'];
-			$this->defaultParams[$default['name']] = $default['value'];
-		}
-	}
+        foreach ($params as $p => $param) {
+            $default = $param['defaultParameterValue'];
+            $this->defaultParams[$default['name']] = $default['value'];
+        }
+    }
 
-	/**
-	 * @return true if the last build was successful
-	 */
-	public function isHealthy()
-	{
-		// TODO default if property is not defined?
-		$lastSuccess = $this->metadata['lastSuccessfulBuild']['number'];
-		$lastCompleted = $this->metadata['lastCompletedBuild']['number'];
+    /**
+     * @return true if the last build was successful
+     */
+    public function isHealthy()
+    {
+        // TODO default if property is not defined?
+        $lastSuccess = $this->metadata['lastSuccessfulBuild']['number'];
+        $lastCompleted = $this->metadata['lastCompletedBuild']['number'];
 
-		// Another alternative is lastBuild.result == 'SUCCESS'
-		return $lastSuccess === $lastCompleted;
-	}
+        // Another alternative is lastBuild.result == 'SUCCESS'
+        return $lastSuccess === $lastCompleted;
+    }
 
-	/**
-	 * @see isHealthy()
-	 * @deprecated
-	 */
-	public function is_healthy()
-	{
-		return $this->isHealthy();
-	}
+    /**
+     * @see isHealthy()
+     * @deprecated
+     */
+    public function is_healthy()
+    {
+        return $this->isHealthy();
+    }
 
-	/**
-	 * Enqueue a build with Jenkins
-	 *
-	 * @param array $buildParams Any param values to override the project defaults
-	 * @throws JenkinsApiException
-	 */
-	public function start(array $buildParams = [])
-	{
-		$lastCompletedBuildId = $this->lastBuildId(true);
-		$this->logger->debug('Last completed build: ' . $lastCompletedBuildId);
+    /**
+     * Enqueue a build with Jenkins
+     *
+     * @param array $buildParams Any param values to override the project defaults
+     * @throws JenkinsApiException
+     */
+    public function start(array $buildParams = [])
+    {
+        $lastCompletedBuildId = $this->lastBuildId(true);
+        $this->logger->debug('Last completed build: ' . $lastCompletedBuildId);
 
-		$params_json = $this->buildParamsJson($buildParams);
-		$this->postJson(
-			['build'],
-			[
-				'json' => $params_json,
-				'delay' => '0sec',
-			]);
+        $params_json = $this->buildParamsJson($buildParams);
+        $this->postJson(
+            ['build'],
+            [
+                'json' => $params_json,
+                'delay' => '0sec',
+            ]);
 
-		// This gives back the general information about job
-		$metadata = $this->getJson([]);
+        // This gives back the general information about job
+        $metadata = $this->getJson([]);
 
-		if ($metadata['inQueue'] > 0) {
-			// Build is queued, but must wait and hasn't been assigned a number
-			$this->myBuildId = $metadata['nextBuildNumber'];
-			$this->logger->debug('Queued build: ' . $this->myBuildId);
+        if ($metadata['inQueue'] > 0) {
+            // Build is queued, but must wait and hasn't been assigned a number
+            $this->myBuildId = $metadata['nextBuildNumber'];
+            $this->logger->debug('Queued build: ' . $this->myBuildId);
 
-			// @TODO Sleep until build should be running?
-			// sleep($metadata['queueItem']['buildableStartMilliseconds']);
-		} else {
-			// If no builds blocking (system wide), this build starts right away
-			// ...and has been assigned a build number
-			$this->myBuildId = $this->lastBuildId(false);
-			$this->logger->debug('Started build: ' . $this->myBuildId);
-		}
+            // @TODO Sleep until build should be running?
+            // sleep($metadata['queueItem']['buildableStartMilliseconds']);
+        } else {
+            // If no builds blocking (system wide), this build starts right away
+            // ...and has been assigned a build number
+            $this->myBuildId = $this->lastBuildId(false);
+            $this->logger->debug('Started build: ' . $this->myBuildId);
+        }
 
-		if ($lastCompletedBuildId == $this->myBuildId) {
-			throw new JenkinsApiException('Could not create new jenkins job. Quitting.');
-		}
+        if ($lastCompletedBuildId == $this->myBuildId) {
+            throw new JenkinsApiException('Could not create new jenkins job. Quitting.');
+        }
 
-		return $this->myBuildId;
-	}
+        return $this->myBuildId;
+    }
 
-	/**
-	 * Build number of the last build
-	 * @param $completed - If true, get last *completed* build, otherwise last build
-	 */
-	private function lastBuildId($completed = false)
-	{
-		$buildType = $completed ? 'lastCompletedBuild' : 'lastBuild';
+    /**
+     * Build number of the last build
+     * @param $completed - If true, get last *completed* build, otherwise last build
+     */
+    private function lastBuildId($completed = false)
+    {
+        $buildType = $completed ? 'lastCompletedBuild' : 'lastBuild';
 
-		$lastBuildData = $this->getJson([$buildType]);
+        $lastBuildData = $this->getJson([$buildType]);
 
-		return $lastBuildData['number'];
-	}
+        return $lastBuildData['number'];
+    }
 
-	/**
-	 * @return string Success, Failure, or Incomplete
-	 */
-	public function queryStatus()
-	{
-		$jobData = $this->getJson(array("{$this->myBuildId}"));
+    /**
+     * @return string Success, Failure, or Incomplete
+     */
+    public function queryStatus()
+    {
+        $jobData = $this->getJson(array("{$this->myBuildId}"));
 
-		return $jobData['result'];
-	}
+        return $jobData['result'];
+    }
 
-	/**
-	 * @see queryStatus()
-	 * @deprecated
-	 */
-	public function query_status()
-	{
-		return $this->queryStatus();
-	}
+    /**
+     * @see queryStatus()
+     * @deprecated
+     */
+    public function query_status()
+    {
+        return $this->queryStatus();
+    }
 
-	/**
-	 * Keep polling jenkins every $pollPeriod seconds until build is complete
-	 * @param int $pollPeriod
-	 * @param int $timeoutAfter Maximum total minutes to poll before giving up
-	 */
-	public function waitUntilComplete($pollPeriod = 1, $timeoutAfter = 45)
-	{
-		// Poll jenkins until last build number is our build number or greater
-		$lastCompletedBuild = $this->lastBuildId(true);
-		$started = time();
-		while ($lastCompletedBuild < $this->myBuildId
-			&& time() < (60 * $timeoutAfter) + $started)
-		{
-			sleep($pollPeriod);
+    /**
+     * Keep polling jenkins every $pollPeriod seconds until build is complete
+     * @param int $pollPeriod
+     * @param int $timeoutAfter Maximum total minutes to poll before giving up
+     */
+    public function waitUntilComplete($pollPeriod = 1, $timeoutAfter = 45)
+    {
+        // Poll jenkins until last build number is our build number or greater
+        $lastCompletedBuild = $this->lastBuildId(true);
+        $started = time();
+        while ($lastCompletedBuild < $this->myBuildId
+            && time() < (60 * $timeoutAfter) + $started) {
+            sleep($pollPeriod);
 
-			// Consider persisting curl handle between these requests
-			// ...if we see perf. degredation
-			$lastCompletedBuild = $this->lastBuildId(true);
-		}
-	}
+            // Consider persisting curl handle between these requests
+            // ...if we see perf. degredation
+            $lastCompletedBuild = $this->lastBuildId(true);
+        }
+    }
 
-	/**
-	 * @see waitUntilComplete()
-	 * @deprecated
-	 */
-	public function wait_until_complete($pollPeriod = 1, $timeoutAfter = 45)
-	{
-		$this->waitUntilComplete($pollPeriod, $timeoutAfter);
-	}
+    /**
+     * @see waitUntilComplete()
+     * @deprecated
+     */
+    public function wait_until_complete($pollPeriod = 1, $timeoutAfter = 45)
+    {
+        $this->waitUntilComplete($pollPeriod, $timeoutAfter);
+    }
 
-	/**
-	 * Curl Jenkins API for details about job
-	 * @param $resourceItems - List of strings defining path to job resource
-	 * @return array JSON data decoded as PHP array
-	 */
-	private function getJson(array $resourceItems)
-	{
-		return $this->connection->curlJenkinsApi($this->buildApiPath($resourceItems), null);
-	}
+    /**
+     * Curl Jenkins API for details about job
+     * @param $resourceItems - List of strings defining path to job resource
+     * @return array JSON data decoded as PHP array
+     */
+    private function getJson(array $resourceItems)
+    {
+        return $this->connection->curlJenkinsApi($this->buildApiPath($resourceItems), null);
+    }
 
-	/**
-	 * @see getJson but with POST data
-	 * @param array $resourceItems
-	 * @param array $httpPostArray
-	 * @return array JSON data decoded as PHP array
-	 */
-	private function postJson(array $resourceItems, array $httpPostArray)
-	{
-		return $this->connection->curlJenkinsApi($this->buildApiPath($resourceItems), $httpPostArray);
-	}
+    /**
+     * @see getJson but with POST data
+     * @param array $resourceItems
+     * @param array $httpPostArray
+     * @return array JSON data decoded as PHP array
+     */
+    private function postJson(array $resourceItems, array $httpPostArray)
+    {
+        return $this->connection->curlJenkinsApi($this->buildApiPath($resourceItems), $httpPostArray);
+    }
 
-	/**
-	 * The JSON representation of the build parameters expected by the job
-	 * coalescing defaults and $override values
-	 * @param array $override Override the default values defined by project
-	 * @return string JSON representation of build parameters
-	 */
-	private function buildParamsJson(array $override)
-	{
-		$params = [];
-		foreach ($this->defaultParams as $name => $value) {
-			$params[] = [
-				'name' => $name,
-				'value' => isset($override[$name]) ?  $override[$name] : $value,
-			];
-		}
+    /**
+     * The JSON representation of the build parameters expected by the job
+     * coalescing defaults and $override values
+     * @param array $override Override the default values defined by project
+     * @return string JSON representation of build parameters
+     */
+    private function buildParamsJson(array $override)
+    {
+        $params = [];
+        foreach ($this->defaultParams as $name => $value) {
+            $params[] = [
+                'name' => $name,
+                'value' => isset($override[$name]) ? $override[$name] : $value,
+            ];
+        }
 
-		$jenkinsParams = ['parameter' => $params];
-		return json_encode($jenkinsParams);
-	}
+        $jenkinsParams = ['parameter' => $params];
+        return json_encode($jenkinsParams);
+    }
 
-	private function buildApiPath(array $resourceItems)
-	{
-		$resourcePath = '';
+    private function buildApiPath(array $resourceItems)
+    {
+        $resourcePath = '';
         if ($resourceItems !== []) {
             $resourcePath = implode('/', $resourceItems);
             $resourcePath .= '/';
         }
 
-		return "{$this->baseApiPath}{$resourcePath}api/json";
-	}
+        return "{$this->baseApiPath}{$resourcePath}api/json";
+    }
 }
 

--- a/src/Bart/Jenkins/Job.php
+++ b/src/Bart/Jenkins/Job.php
@@ -101,6 +101,7 @@ class Job
 	}
 
 	/**
+	 * @see isHealthy()
 	 * @deprecated
 	 */
 	public function is_healthy()
@@ -175,6 +176,7 @@ class Job
 	}
 
 	/**
+	 * @see queryStatus()
 	 * @deprecated
 	 */
 	public function query_status()
@@ -204,6 +206,7 @@ class Job
 	}
 
 	/**
+	 * @see waitUntilComplete()
 	 * @deprecated
 	 */
 	public function wait_until_complete($pollPeriod = 1, $timeoutAfter = 45)

--- a/test/Bart/Jenkins/ConnectionTest.php
+++ b/test/Bart/Jenkins/ConnectionTest.php
@@ -1,0 +1,125 @@
+<?php
+namespace Bart\Jenkins;
+
+
+use Bart\BaseTestCase;
+use Bart\Diesel;
+
+class ConnectionTest extends BaseTestCase
+{
+    private static $fakeDomain = 'example';
+    private static $fakeApiPath = 'fake/api/path';
+
+    private static $fakeApiResponseSuccess = [
+        'info' => ['http_code' => 200],
+        'content' => '{"key":"value"}',
+    ];
+
+    private static $fakeApiResponseFailure = [
+        'info' => ['http_code' => 403],
+        'content' => 'error message',
+    ];
+
+    public function testCurlBaseCase()
+    {
+        $connection = new Connection(self::$fakeDomain);
+        $this->mockCurl(
+            function($mockCurl) {$mockCurl->get()->once()->return_value(self::$fakeApiResponseSuccess);}
+        );
+        $connection->curlJenkinsApi(self::$fakeApiPath);
+    }
+
+    public function testCurlWithHTTPS()
+    {
+        $expectedProtocol = 'https';
+        $expectedPort = 443;
+        $connection = new Connection(self::$fakeDomain, $expectedProtocol);
+        $this->mockCurl(
+            function($mockCurl) {$mockCurl->get()->once()->return_value(self::$fakeApiResponseSuccess);},
+            $expectedProtocol,
+            $expectedPort
+        );
+        $connection->curlJenkinsApi(self::$fakeApiPath);
+    }
+
+    public function testCurlWithCustomPort()
+    {
+        $expectedProtocol = 'http';
+        $expectedPort = 43000;
+        $connection = new Connection(self::$fakeDomain, $expectedProtocol, $expectedPort);
+        $this->mockCurl(
+            function($mockCurl) {$mockCurl->get()->once()->return_value(self::$fakeApiResponseSuccess);},
+            $expectedProtocol,
+            $expectedPort
+        );
+        $connection->curlJenkinsApi(self::$fakeApiPath);
+    }
+
+    public function testCurlWithAuthSet()
+    {
+        $expectedProtocol = 'http';
+        $expectedPort = 8080;
+        $connection = new Connection(self::$fakeDomain);
+
+        $fakeUser = 'user';
+        $fakeToken = 'token';
+        $connection->setAuth($fakeUser, $fakeToken);
+
+        $this->mockCurl(
+            function($mockCurl) use ($fakeUser, $fakeToken) {
+                $mockCurl->setPhpCurlOpts([CURLOPT_USERPWD => "{$fakeUser}:{$fakeToken}"])->once();
+                $mockCurl->get()->once()->return_value(self::$fakeApiResponseSuccess);
+            },
+            $expectedProtocol,
+            $expectedPort
+        );
+        $connection->curlJenkinsApi(self::$fakeApiPath);
+    }
+
+    public function testCurlWithPostDataSet()
+    {
+        $postData = ['fake_key' => 'fake_value'];
+        $connection = new Connection(self::$fakeDomain);
+        $this->mockCurl(
+            function($mockCurl) use ($postData) {
+                $mockCurl->post('', [], $postData)->once()->return_value(self::$fakeApiResponseSuccess);
+            }
+        );
+        $connection->curlJenkinsApi(self::$fakeApiPath, $postData);
+    }
+
+    public function testCurlFailure()
+    {
+        $connection = new Connection(self::$fakeDomain);
+        $this->mockCurl(
+            function($mockCurl) {
+                $mockCurl->get()->once()->return_value(self::$fakeApiResponseFailure);
+            }
+        );
+        $this->setExpectedException('\Bart\Jenkins\JenkinsApiException');
+        $connection->curlJenkinsApi(self::$fakeApiPath);
+    }
+
+    /**
+     * Mocks out the Diesel Curl class
+     * @param callable $configure
+     * @param string $expectedProtocol
+     * @param string $expectedPort
+     * @throws \Bart\DieselException
+     */
+    private function mockCurl($configure, $expectedProtocol = 'http', $expectedPort = '8080')
+    {
+        $fullUrl = "${expectedProtocol}://" . self::$fakeDomain . ":{$expectedPort}/". self::$fakeApiPath;
+        $mockCurl = $this->shmock('\Bart\Curl', function ($curlStub) use ($configure) {
+            $configure($curlStub);
+        }, true);
+
+        Diesel::registerInstantiator('\Bart\Curl', function ($url, $port) use ($mockCurl, $fullUrl, $expectedPort) {
+            $this->assertEquals($fullUrl, $url, 'Full Jenkins REST API URL');
+            $this->assertEquals($expectedPort, $port, 'Port');
+            return $mockCurl;
+        });
+
+    }
+
+}

--- a/test/Bart/Jenkins/Job_Test.php
+++ b/test/Bart/Jenkins/Job_Test.php
@@ -5,7 +5,9 @@ use Bart\BaseTestCase;
 
 class Job_Test extends BaseTestCase
 {
-	public static $projectPath = 'job/chuck norris';
+	public static $projectPath = 'job/chuck norris/job/chuck norris two';
+	public static $expectedApiPath = '/job/chuck%20norris/job/chuck%20norris%20two/api/json';
+
 	public function testIsHealthy()
 	{
 		$conn = $this->configureForHealthTests(123, 123);
@@ -38,7 +40,7 @@ class Job_Test extends BaseTestCase
 		/** @var \Bart\Jenkins\Connection $conn */
 		return $this->shmock('\Bart\Jenkins\Connection', function ($stub) use ($returnContent)
 			/** @var \Bart\Jenkins\Connection $stub */ {
-			$stub->curlJenkinsApi()->once()->return_value($returnContent);
+			$stub->curlJenkinsApi(self::$expectedApiPath)->once()->return_value($returnContent);
 		}, true);
 	}
 

--- a/test/Bart/Jenkins/Job_Test.php
+++ b/test/Bart/Jenkins/Job_Test.php
@@ -15,7 +15,7 @@ class Job_Test extends \Bart\BaseTestCase
 	public function configure_for_health_tests($last_success, $last_completed)
 	{
 		$domain = self::$domain;
-		$url = "http://$domain:8080/job/" . rawurlencode(self::$job_name) . '//api/json';
+		$url = "http://$domain:8080/job/" . rawurlencode(self::$job_name) . '/api/json';
 
 		// The essential metadata the Job class needs to instantiate
 		$norris_metadata = array(
@@ -44,7 +44,12 @@ class Job_Test extends \Bart\BaseTestCase
 		$mock_curl->expects($this->once())
 			->method('get')
 			->with($this->equalTo(''), $this->equalTo(array()))
-		    ->will($this->returnValue(array('content' => $json)));
+		    ->will($this->returnValue(
+				[
+					'info' => ['http_code' => 200],
+					'content' => $json
+				]
+			));
 
 		$phpu = $this;
 		Diesel::registerInstantiator('Bart\Curl',
@@ -73,7 +78,7 @@ class Job_Test extends \Bart\BaseTestCase
 	{
 		$domain = self::$domain;
 		$job_name = self::$job_name;
-		$url = "http://$domain:8080/job/" . rawurlencode($job_name) . '//api/json';
+		$url = "http://$domain:8080/job/" . rawurlencode($job_name) . '/api/json';
 		$this->configure_diesel($url, json_encode(array('buildable' => 0), true));
 
 		try
@@ -106,7 +111,7 @@ class Job_Test extends \Bart\BaseTestCase
 		}
 		catch(\Exception $e)
 		{
-			$this->assertEquals('Must provide a job name', $e->getMessage());
+			$this->assertEquals('Must provide a base job name', $e->getMessage());
 		}
 	}
 }

--- a/test/Bart/Jenkins/Job_Test.php
+++ b/test/Bart/Jenkins/Job_Test.php
@@ -1,118 +1,71 @@
 <?php
 namespace Bart\Jenkins;
 
-use Bart\Diesel;
-use Bart\Curl;
+use Bart\BaseTestCase;
 
-class Job_Test extends \Bart\BaseTestCase
+class Job_Test extends BaseTestCase
 {
-	public static $domain = 'www.norris.com';
-	public static $job_name = 'chuck norris';
+	public static $projects = ['chuck norris'];
+
+
+
+	public function testIsHealthy()
+	{
+		$conn = $this->configureForHealthTests(123, 123);
+		$job = new Job($conn, self::$projects);
+		$this->assertTrue($job->is_healthy(), 'Expected that job would be healthy');
+	}
+
+	public function testIsUnhealthy()
+	{
+		$conn = $this->configureForHealthTests(123, 122);
+		$job = new Job($conn, self::$projects);
+		$this->assertFalse($job->is_healthy(), 'Expected that job would be unhealthy');
+	}
+
+	public function testBuildIsDisabled()
+	{
+        $conn = $this->createMockConnection();
+        $this->setExpectedException('\InvalidArgumentException');
+        new Job($conn, self::$projects);
+
+	}
+
+	/**
+	 * Create a mock Jenkins connection
+	 * @param array $returnContent The data that Jenkins should return (as an array)
+	 * @return Connection A mock Jenkins Connection
+	 */
+	private function createMockConnection(array $returnContent = [])
+	{
+		/** @var \Bart\Jenkins\Connection $conn */
+		return $this->shmock('\Bart\Jenkins\Connection', function ($stub) use ($returnContent)
+			/** @var \Bart\Jenkins\Connection $stub */ {
+			$stub->curlJenkinsApi()->once()->return_value($returnContent);
+		}, true);
+	}
 
 	/**
 	 * Mock the metadata returned by curl
+	 * @param $lastSuccess
+	 * @param $lastCompleted
+	 * @return Connection A mock Jenkins Connection
 	 */
-	public function configure_for_health_tests($last_success, $last_completed)
+	private function configureForHealthTests($lastSuccess, $lastCompleted)
 	{
-		$domain = self::$domain;
-		$url = "http://$domain:8080/job/" . rawurlencode(self::$job_name) . '/api/json';
-
 		// The essential metadata the Job class needs to instantiate
-		$norris_metadata = array(
+		$norrisMetadata = array(
 			'buildable' => 1,
 			'property' => array(
 				'0' => array(
 					'parameterDefinitions' => array(),
 				),
 			),
-			'lastSuccessfulBuild' => array('number' => $last_success),
-			'lastCompletedBuild' => array('number' => $last_completed),
+			'lastSuccessfulBuild' => array('number' => $lastSuccess),
+			'lastCompletedBuild' => array('number' => $lastCompleted),
 		);
 
-		$json = json_encode($norris_metadata, true);
-		$this->configure_diesel($url, $json);
-	}
-
-	/**
-	 * Configure Job for injection of stub Curl with $json
-	 * @param string $url Expected Jenkins URL
-	 * @param JSON $json
-	 */
-	private function configure_diesel($url, $json)
-	{
-		$mock_curl = $this->getMock('\\Bart\\Curl', array(), array(), '', false);
-		$mock_curl->expects($this->once())
-			->method('get')
-			->with($this->equalTo(''), $this->equalTo(array()))
-		    ->will($this->returnValue(
-				[
-					'info' => ['http_code' => 200],
-					'content' => $json
-				]
-			));
-
-		$phpu = $this;
-		Diesel::registerInstantiator('Bart\Curl',
-			function($urlParam, $portParam) use($phpu, $url, $mock_curl) {
-				$phpu->assertEquals($url, $urlParam, 'url');
-				$phpu->assertEquals(8080, $portParam, 'port');
-				return $mock_curl;
-			});
-	}
-
-	public function test_is_healthy()
-	{
-		$this->configure_for_health_tests(123, 123);
-		$job = new Job(self::$domain, self::$job_name);
-		$this->assertTrue($job->is_healthy(), 'Expected that job would be healthy');
-	}
-
-	public function test_is_unhealthy()
-	{
-		$this->configure_for_health_tests(123, 122);
-		$job = new Job(self::$domain, self::$job_name);
-		$this->assertFalse($job->is_healthy(), 'Expected that job would be unhealthy');
-	}
-
-	public function test_build_is_disabled()
-	{
-		$domain = self::$domain;
-		$job_name = self::$job_name;
-		$url = "http://$domain:8080/job/" . rawurlencode($job_name) . '/api/json';
-		$this->configure_diesel($url, json_encode(array('buildable' => 0), true));
-
-		try
-		{
-			new Job($domain, $job_name);
-			$this->fail('Expected exception on disabled job');
-		}
-		catch (\Exception $e)
-		{
-			$this->assertEquals($e->getMessage(), "Project $job_name is disabled");
-		}
-	}
-
-	public function test_fails_on_missing_param()
-	{
-		try
-		{
-			new Job('', '');
-			$this->fail('Should fail when missing a daomin');
-		}
-		catch(\Exception $e)
-		{
-			$this->assertEquals('Must provide a valid domain', $e->getMessage());
-		}
-
-		try
-		{
-			new Job('domain', '');
-			$this->fail('Should fail when missing a job name');
-		}
-		catch(\Exception $e)
-		{
-			$this->assertEquals('Must provide a base job name', $e->getMessage());
-		}
+		return $this->createMockConnection($norrisMetadata);
 	}
 }
 

--- a/test/Bart/Jenkins/Job_Test.php
+++ b/test/Bart/Jenkins/Job_Test.php
@@ -5,21 +5,18 @@ use Bart\BaseTestCase;
 
 class Job_Test extends BaseTestCase
 {
-	public static $projects = ['chuck norris'];
-
-
-
+	public static $projectPath = 'job/chuck norris';
 	public function testIsHealthy()
 	{
 		$conn = $this->configureForHealthTests(123, 123);
-		$job = new Job($conn, self::$projects);
+		$job = new Job($conn, self::$projectPath);
 		$this->assertTrue($job->is_healthy(), 'Expected that job would be healthy');
 	}
 
 	public function testIsUnhealthy()
 	{
 		$conn = $this->configureForHealthTests(123, 122);
-		$job = new Job($conn, self::$projects);
+		$job = new Job($conn, self::$projectPath);
 		$this->assertFalse($job->is_healthy(), 'Expected that job would be unhealthy');
 	}
 
@@ -27,7 +24,7 @@ class Job_Test extends BaseTestCase
 	{
         $conn = $this->createMockConnection();
         $this->setExpectedException('\InvalidArgumentException');
-        new Job($conn, self::$projects);
+        new Job($conn, self::$projectPath);
 
 	}
 


### PR DESCRIPTION
This commit allows the Jenkins Job class to handle both HTTP as well as
HTTPS protocol. In addition, it allows the specification of lower
level Jenkins projects, in addition to just top-level projects. Finally,
support for user authentication is also added.