### PR TITLE
Refactor StopTheLineJenkins git hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "php": ">=5.4.0",
     "chobie/jira-api-restclient": "2.0.*@dev",
     "apache/log4php": "2.3.0",
-    "phpoption/phpoption": "^1.5"
+    "phpoption/phpoption": "^1.5",
+    "eloquent/enumeration": "^5.1"
   },
   "require-dev": {
     "phpunit/phpunit": "3.7.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "99af49b827dd7bfa761ea4a8e7d68790",
-    "content-hash": "baf65b54fda71d60ea8b05dba83a95d9",
+    "hash": "003a81ca19318bf6ee0e4a775f0a0292",
+    "content-hash": "d9ce10eb749c75a9070aaebf27a43083",
     "packages": [
         {
             "name": "apache/log4php",
@@ -47,7 +47,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chobie/jira-api-restclient/zipball/661e028fa3e96451202307259c4695d25df1a393",
+                "url": "https://api.github.com/repos/chobie/jira-api-restclient/zipball/4b1b2a4230f987caae601f5d0ca7486445293453",
                 "reference": "661e028fa3e96451202307259c4695d25df1a393",
                 "shasum": ""
             },
@@ -86,6 +86,57 @@
                 "rest"
             ],
             "time": "2014-07-27 11:55:20"
+        },
+        {
+            "name": "eloquent/enumeration",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/eloquent/enumeration.git",
+                "reference": "0242859435d9b135939816858348556d3cde9e3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/eloquent/enumeration/zipball/0242859435d9b135939816858348556d3cde9e3c",
+                "reference": "0242859435d9b135939816858348556d3cde9e3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "icecave/archer": "dev-develop",
+                "phpunit/phpunit": "^4",
+                "sami/sami": "^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Eloquent\\Enumeration\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Erin Millard",
+                    "email": "ezzatron@gmail.com",
+                    "homepage": "http://ezzatron.com/"
+                }
+            ],
+            "description": "An enumeration implementation for PHP.",
+            "homepage": "https://github.com/eloquent/enumeration",
+            "keywords": [
+                "class",
+                "enum",
+                "enumeration",
+                "multiton",
+                "set",
+                "type"
+            ],
+            "time": "2015-11-03 22:21:38"
         },
         {
             "name": "phpoption/phpoption",

--- a/src/Bart/GitHook/Directives.php
+++ b/src/Bart/GitHook/Directives.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Bart\GitHook;
+
+use Eloquent\Enumeration\AbstractEnumeration;
+
+/**
+ * Class Directives
+ * @package Bart\GitHook
+ */
+class Directives extends AbstractEnumeration
+{
+    /**
+     * Used by StopTheLineJenkins Hook Action to allow commits that have this
+     * directive to go through, when the build is broken.
+     */
+    const buildFix = '{buildFix}';
+    
+}

--- a/src/Bart/GitHook/Directives.php
+++ b/src/Bart/GitHook/Directives.php
@@ -14,6 +14,6 @@ class Directives extends AbstractEnumeration
      * Used by StopTheLineJenkins Hook Action to allow commits that have this
      * directive to go through, when the build is broken.
      */
-    const buildFix = '{buildFix}';
-    
+    const BUILD_FIX = '{buildFix}';
+
 }

--- a/src/Bart/GitHook/GitHookConfig.php
+++ b/src/Bart/GitHook/GitHookConfig.php
@@ -29,6 +29,12 @@ hook_actions = '\Bart\GitHook\JiraComment', '\Bart\GitHook\GerritAbandon'
 ; %s will be replaced with commit revision hash
 comment_template = 'Commit %s pushed to JIRA. See online at https://git.example.com/?h=%s'
 
+[jenkins]
+; Used by StopTheLineJenkins Hook Action to allow
+; commits that have this directive to go through,
+; when the build is broken. Defaults to {buildfix}.
+build_fix_directive = '{buildfix}'
+
 [notifications]
 ; Optional email address to notify when emergencies are pushed
 emergency_notification_email = emergencies@example.com
@@ -60,6 +66,14 @@ README;
 	public function jiraCommentTemplate()
 	{
 		return $this->getValue('jira', 'comment_template');
+	}
+
+	/**
+	 * @return string Build fix directive used to allow commits that fix builds to go through
+	 */
+	public function jenkinsBuildFixDirective()
+	{
+		return $this->getValue('jenkins', 'build_fix_directive', '{buildFix}', false);
 	}
 
     /**

--- a/src/Bart/GitHook/GitHookConfig.php
+++ b/src/Bart/GitHook/GitHookConfig.php
@@ -29,12 +29,6 @@ hook_actions = '\Bart\GitHook\JiraComment', '\Bart\GitHook\GerritAbandon'
 ; %s will be replaced with commit revision hash
 comment_template = 'Commit %s pushed to JIRA. See online at https://git.example.com/?h=%s'
 
-[jenkins]
-; Used by StopTheLineJenkins Hook Action to allow
-; commits that have this directive to go through,
-; when the build is broken. Defaults to {buildfix}.
-build_fix_directive = '{buildfix}'
-
 [notifications]
 ; Optional email address to notify when emergencies are pushed
 emergency_notification_email = emergencies@example.com
@@ -68,14 +62,6 @@ README;
 		return $this->getValue('jira', 'comment_template');
 	}
 
-	/**
-	 * @return string Build fix directive used to allow commits that fix builds to go through
-	 */
-	public function jenkinsBuildFixDirective()
-	{
-		return $this->getValue('jenkins', 'build_fix_directive', '{buildFix}', false);
-	}
-
     /**
      * @return \string[] List of refs to run git hooks on
      */
@@ -107,6 +93,5 @@ README;
     {
         return $this->getValue('notifications', 'body', '', false);
     }
-
 
 }

--- a/src/Bart/GitHook/StopTheLineJenkins.php
+++ b/src/Bart/GitHook/StopTheLineJenkins.php
@@ -56,10 +56,10 @@ class StopTheLineJenkins extends GitHookAction
 		$this->logger->info('Jenkins job is not healthy...asserting that commit message contains {buildfix} hash');
 		$messageSubject = $commit->messageSubject();
 
-		$buildFixDirective = Directives::buildFix();
+		$buildFixDirective = Directives::BUILD_FIX();
 
 		// Check if commit has buildfix directive
-		if (preg_match("/{$buildFixDirective}/", $messageSubject) > 0) {
+		if (preg_match("/{$buildFixDirective->value()}/", $messageSubject) > 0) {
 			$this->logger->info("Commit has {$buildFixDirective} directive. It attempts to fix build");
 			return;
 		}

--- a/src/Bart/GitHook/StopTheLineJenkins.php
+++ b/src/Bart/GitHook/StopTheLineJenkins.php
@@ -56,9 +56,7 @@ class StopTheLineJenkins extends GitHookAction
 		$this->logger->info('Jenkins job is not healthy...asserting that commit message contains {buildfix} hash');
 		$messageSubject = $commit->messageSubject();
 
-		/** @var GitHookConfig $gitHookConfig */
-		$gitHookConfig = Diesel::create('\Bart\GitHook\GitHookConfig');
-		$buildFixDirective = $gitHookConfig->jenkinsBuildFixDirective();
+		$buildFixDirective = Directives::buildFix();
 
 		// Check if commit has buildfix directive
 		if (preg_match("/{$buildFixDirective}/", $messageSubject) > 0) {

--- a/src/Bart/GitHook/StopTheLineJenkins.php
+++ b/src/Bart/GitHook/StopTheLineJenkins.php
@@ -13,57 +13,57 @@ use Bart\Jenkins\Job;
  */
 class StopTheLineJenkins extends GitHookAction
 {
-	/** @var Job $job **/
-	private $job;
+    /** @var Job $job * */
+    private $job;
 
-	public function __construct()
-	{
-		parent::__construct();
+    public function __construct()
+    {
+        parent::__construct();
 
-		/** @var JenkinsConfig $jenkinsConfig */
-		$jenkinsConfig = Diesel::create('\Bart\Jenkins\JenkinsConfig');
+        /** @var JenkinsConfig $jenkinsConfig */
+        $jenkinsConfig = Diesel::create('\Bart\Jenkins\JenkinsConfig');
 
-		/** @var Connection $connection */
-		$connection = Diesel::create(
-			'\Bart\Jenkins\Connection',
-			$jenkinsConfig->domain(),
-			$jenkinsConfig->protocol(),
-			$jenkinsConfig->port()
-		);
+        /** @var Connection $connection */
+        $connection = Diesel::create(
+            '\Bart\Jenkins\Connection',
+            $jenkinsConfig->domain(),
+            $jenkinsConfig->protocol(),
+            $jenkinsConfig->port()
+        );
 
-		$user = $jenkinsConfig->user();
-		$token = $jenkinsConfig->token();
-		if ($user !== null && $token !== null) {
-			$connection->setAuth($user, $token);
-		}
+        $user = $jenkinsConfig->user();
+        $token = $jenkinsConfig->token();
+        if ($user !== null && $token !== null) {
+            $connection->setAuth($user, $token);
+        }
 
-		/** @var Job job */
-		$this->job = Diesel::create('\Bart\Jenkins\Job', $connection, $jenkinsConfig->jobLocation());
-	}
+        /** @var Job job */
+        $this->job = Diesel::create('\Bart\Jenkins\Job', $connection, $jenkinsConfig->jobLocation());
+    }
 
-	/**
-	 * @param Commit $commit
-	 * @throws GitHookException
-	 * @throws GitException
+    /**
+     * @param Commit $commit
+     * @throws GitHookException
+     * @throws GitException
      */
-	public function run(Commit $commit)
-	{
-		if ($this->job->isHealthy()) {
-			$this->logger->debug('Jenkins job is healthy.');
-			return;
-		}
+    public function run(Commit $commit)
+    {
+        if ($this->job->isHealthy()) {
+            $this->logger->debug('Jenkins job is healthy.');
+            return;
+        }
 
-		$this->logger->info('Jenkins job is not healthy...asserting that commit message contains {buildfix} hash');
-		$messageSubject = $commit->messageSubject();
+        $this->logger->info('Jenkins job is not healthy...asserting that commit message contains {buildfix} hash');
+        $messageSubject = $commit->messageSubject();
 
-		$buildFixDirective = Directives::BUILD_FIX();
+        $buildFixDirective = Directives::BUILD_FIX();
 
-		// Check if commit has buildfix directive
-		if (preg_match("/{$buildFixDirective->value()}/", $messageSubject) > 0) {
-			$this->logger->info("Commit has {$buildFixDirective} directive. It attempts to fix build");
-			return;
-		}
+        // Check if commit has buildfix directive
+        if (preg_match("/{$buildFixDirective->value()}/", $messageSubject) > 0) {
+            $this->logger->info("Commit has {$buildFixDirective} directive. It attempts to fix build");
+            return;
+        }
 
-		throw new GitHookException('Jenkins not healthy and commit does not fix it');
-	}
+        throw new GitHookException('Jenkins not healthy and commit does not fix it');
+    }
 }

--- a/src/Bart/Jenkins/JenkinsConfig.php
+++ b/src/Bart/Jenkins/JenkinsConfig.php
@@ -1,0 +1,89 @@
+<?php
+namespace Bart\Jenkins;
+
+
+use Bart\Configuration\Configuration;
+use Bart\Configuration\ConfigurationException;
+
+class JenkinsConfig extends Configuration
+{
+
+    /**
+     * @return string Sample of how configuration is intended to be defined
+     */
+    public function README()
+    {
+        return <<<README
+; domain and location are the only required fields
+[api]
+domain = 'jenkins.example.com'
+; Defaults to 'http'
+protocol = 'http'
+; Defaults to 8080
+port = 8080
+; user & token default to null for anonymous connections
+user = 'example-user'
+token = 'example-token'
+[job]
+; location specifies the location of the Jenkins job, e.g. if your job is defined in the
+; third level project: Base->Build->Example, the location is specified as below.
+location = 'job/Base/job/Build/job/Example'
+
+README;
+    }
+
+    /**
+     * @return string The domain of the Jenkins instance
+     * @throws ConfigurationException
+     */
+    public function domain()
+    {
+        return $this->getValue('api', 'domain');
+    }
+
+    /**
+     * @return string Transfer protocol (http or https)
+     * @throws ConfigurationException
+     */
+    public function protocol()
+    {
+        return $this->getValue('api', 'protocol', 'http', false);
+    }
+
+    /**
+     * @return string The port that the Jenkins instance is running on
+     * @throws ConfigurationException
+     */
+    public function port()
+    {
+        return $this->getValue('api', 'port', 8080, false);
+    }
+
+    /**
+     * @return string Jenkins API user
+     * @throws ConfigurationException
+     */
+    public function user()
+    {
+        return $this->getValue('api', 'user', null, false);
+    }
+
+    /**
+     * @return string Jenkins API token corresponding to the Jenkins API user
+     * @throws ConfigurationException
+     */
+    public function token()
+    {
+        return $this->getValue('api', 'token', null, false);
+    }
+
+    /**
+     * @return string The location of the Jenkins job.
+     * @throws ConfigurationException
+     */
+    public function jobLocation()
+    {
+        return $this->getValue('job', 'location', null, false);
+    }
+
+}

--- a/src/Bart/Jenkins/JenkinsConfig.php
+++ b/src/Bart/Jenkins/JenkinsConfig.php
@@ -51,7 +51,7 @@ README;
     }
 
     /**
-     * @return string The port that the Jenkins instance is running on
+     * @return int The port that the Jenkins instance is running on
      * @throws ConfigurationException
      */
     public function port()

--- a/test/Bart/Git/CommitTest.php
+++ b/test/Bart/Git/CommitTest.php
@@ -188,7 +188,7 @@ Change-Id: Iecb840ccccf70a79ae622c583761107aa1a1b7b9';
      * @param BaseTestCase $phpu
      * @param string $revision
      * @param callable $configure Shmock configuration function
-     * @return mixed
+     * @return Commit
      */
     public static function getStubCommit(BaseTestCase $phpu, $revision = 'HEAD', callable $configure = null)
     {

--- a/test/Bart/GitHook/StopTheLineJenkinsTest.php
+++ b/test/Bart/GitHook/StopTheLineJenkinsTest.php
@@ -6,8 +6,6 @@ use Bart\Git\CommitTest;
 
 class StopTheLineJenkinsTest extends TestBase
 {
-    private static $buildFixDirective = '{buildFix}';
-
     public function testHealthyBuild()
     {
         $this->mockJenkinsJobWithDependencies();
@@ -35,10 +33,6 @@ class StopTheLineJenkinsTest extends TestBase
     public function testUnhealthyBuildAndValidBuildFixDirectives($message)
     {
         $this->mockJenkinsJobWithDependencies(false);
-        $this->shmockAndDieselify('\Bart\GitHook\GitHookConfig', function ($hConfigs) {
-            $hConfigs->jenkinsBuildFixDirective()->once()->return_value(self::$buildFixDirective);
-        }, true);
-
         $mockCommit = CommitTest::getStubCommit($this, 'HEAD', function ($head) use ($message) {
             $head->messageSubject()->once()->return_value($message);
         });
@@ -64,10 +58,6 @@ class StopTheLineJenkinsTest extends TestBase
     public function testUnhealthyBuildAndInvalidBuildFixDirectives($message)
     {
         $this->mockJenkinsJobWithDependencies(false);
-        $this->shmockAndDieselify('\Bart\GitHook\GitHookConfig', function ($hConfigs) {
-            $hConfigs->jenkinsBuildFixDirective()->once()->return_value(self::$buildFixDirective);
-        }, true);
-
         $mockCommit = CommitTest::getStubCommit($this, 'HEAD', function ($head) use ($message) {
             $head->messageSubject()->once()->return_value($message);
         });

--- a/test/Bart/GitHook/StopTheLineJenkinsTest.php
+++ b/test/Bart/GitHook/StopTheLineJenkinsTest.php
@@ -2,94 +2,108 @@
 namespace Bart\GitHook;
 
 use Bart\Diesel;
+use Bart\Git\CommitTest;
 
 class StopTheLineJenkinsTest extends TestBase
 {
-	private static $conf = array(
-		'jenkins' => array(
-			'host' => 'jenkins.host.com',
-		));
+    private static $buildFixDirective = '{buildFix}';
 
-	public function test_green_jenkins_job_with_configurable_job_name()
-	{
-		$conf = self::$conf;
-		$conf['jenkins']['job_name'] = 'jenkins php unit job';
+    public function testHealthyBuild()
+    {
+        $this->mockJenkinsJobWithDependencies();
+        $mockCommit = CommitTest::getStubCommit($this, 'HEAD', function ($head) {
+            $head->messageSubject()->never();
+        });
+        $stopTheLineJenkins = new StopTheLineJenkins();
+        $stopTheLineJenkins->run($mockCommit);
+    }
 
-		$stlg = $this->configure_for($conf, true, $conf['jenkins']['job_name']);
-		$stlg['stl']->run('hash');
-	}
+    public function dataProviderValidBuildFixDirectives()
+    {
+        return [
+            ['{buildFix} test message'],
+            ['{buildFix}test message'],
+            ['test message {buildFix}'],
+            ['test {buildFix} message'],
+        ];
+    }
 
-	public function test_green_jenkins_job_with_default_job_name()
-	{
-		$stlg = $this->configure_for(self::$conf, true, 'Gorg');
-		$stlg['stl']->run('hash');
-	}
+    /**
+     * @dataProvider dataProviderValidBuildFixDirectives
+     * @param string $message Git commit message subject
+     */
+    public function testUnhealthyBuildAndValidBuildFixDirectives($message)
+    {
+        $this->mockJenkinsJobWithDependencies(false);
+        $this->shmockAndDieselify('\Bart\GitHook\GitHookConfig', function ($hConfigs) {
+            $hConfigs->jenkinsBuildFixDirective()->once()->return_value(self::$buildFixDirective);
+        }, true);
 
-	public function test_commit_msg_does_not_contain_buildfix()
-	{
-		$stlg = $this->configure_for(self::$conf, false, 'Gorg');
-		$stl = $stlg['stl'];
+        $mockCommit = CommitTest::getStubCommit($this, 'HEAD', function ($head) use ($message) {
+            $head->messageSubject()->once()->return_value($message);
+        });
 
-		$mock_git = $stlg['git'];
-		$mock_git->expects($this->once())
-			->method('get_commit_msg')
-			->with($this->equalTo('hash'))
-			->will($this->returnValue('The commit message'));
+        $stopTheLineJenkins = new StopTheLineJenkins();
+        $stopTheLineJenkins->run($mockCommit);
+    }
 
-		$this->assertThrows('\Exception', 'Jenkins not healthy', function() use($stl) {
-			$stl->run('hash');
-		});
-	}
+    public function dataProviderInvalidBuildFixDirectives()
+    {
+        return [
+            ['message'],
+            ['test message'],
+            ['{invalidBuildFix}test message'],
+            ['test message {BuildFix}'],
+        ];
+    }
 
-	public function test_multi_line_commit_msg_contains_buildfix()
-	{
-		$msg = 'some message
-			some more messages
+    /**
+     * @dataProvider dataProviderInvalidBuildFixDirectives
+     * @param string $message Git commit message subject
+     */
+    public function testUnhealthyBuildAndInvalidBuildFixDirectives($message)
+    {
+        $this->mockJenkinsJobWithDependencies(false);
+        $this->shmockAndDieselify('\Bart\GitHook\GitHookConfig', function ($hConfigs) {
+            $hConfigs->jenkinsBuildFixDirective()->once()->return_value(self::$buildFixDirective);
+        }, true);
 
-			and then again, a few others
+        $mockCommit = CommitTest::getStubCommit($this, 'HEAD', function ($head) use ($message) {
+            $head->messageSubject()->once()->return_value($message);
+        });
 
-			{buildfix}
+        $stopTheLineJenkins = new StopTheLineJenkins();
+        $this->setExpectedException('\Bart\GitHook\GitHookException');
+        $stopTheLineJenkins->run($mockCommit);
+    }
 
-			It happened in Monterey';
+    /**
+     * Stub the expected configuration
+     * @param bool $buildHealth
+     */
+    private function mockJenkinsJobWithDependencies($buildHealth = true)
+    {
+        $this->shmockAndDieselify('\Bart\Jenkins\JenkinsConfig', function ($jConfigs) {
+            $jConfigs->domain()->once()->return_value('jenkins.example.com');
+            $jConfigs->port()->once()->return_value('8080');
+            $jConfigs->protocol()->once()->return_value('http');
+            $jConfigs->user()->once()->return_value('user');
+            $jConfigs->token()->once()->return_value('token');
+            $jConfigs->jobLocation()->once()->return_value('job/Base/job/Build');
+        }, true);
 
-		$stlg = $this->configure_for(self::$conf, false, 'Gorg');
-		$stl = $stlg['stl'];
+        $mockConnection = $this->shmockAndDieselify('\Bart\Jenkins\Connection', function ($connection) {
+            $connection->setAuth()->once();
+        }, true);
 
-		$mock_git = $stlg['git'];
-		$mock_git->expects($this->once())
-			->method('get_commit_msg')
-			->with($this->equalTo('hash'))
-			->will($this->returnValue($msg));
+        $mockJob = $this->shmock('\Bart\Jenkins\Job', function ($jobStub) use ($buildHealth) {
+            $jobStub->isHealthy()->once()->return_value($buildHealth);
+        }, true);
 
-		$stl->run('hash');
-	}
-
-	private function configure_for($conf, $is_healthy, $job_name)
-	{
-		$mock_job = $this->getMock('\\Bart\\Jenkins\\Job', array(), array(), '', false);
-
-		$mock_job->expects($this->once())
-			->method('is_healthy')
-			->will($this->returnValue($is_healthy));
-
-		$gitStub = $this->getGitStub();
-
-		$phpu = $this;
-		Diesel::registerInstantiator('Bart\Jenkins\Job',
-			function($host, $jobNameParam) use($phpu, $conf, $job_name, $mock_job) {
-				$phpu->assertEquals($job_name, $jobNameParam,
-						'Jenkins job name');
-
-				$phpu->assertEquals($conf['jenkins']['host'], $host,
-						'Jenkins host');
-
-				return $mock_job;
-		});
-
-		return array(
-			'stl' => new StopTheLineJenkins($conf, '', 'Gorg'),
-			'git' => $gitStub,
-		);
-	}
+        Diesel::registerInstantiator('\Bart\Jenkins\Job', function ($connection) use ($mockJob, $mockConnection) {
+            $this->assertEquals($mockConnection, $connection, '\Bart\Jenkins\Connection object');
+            return $mockJob;
+        });
+    }
 }
 

--- a/test/Bart/Jenkins/JenkinsConfigTest.php
+++ b/test/Bart/Jenkins/JenkinsConfigTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Bart\Jenkins;
+
+use Bart\BaseTestCase;
+use Bart\Configuration\ConfigurationBaseTests;
+
+class JenkinsConfigTest extends BaseTestCase
+{
+	use ConfigurationBaseTests;
+
+	private function configFileName()
+	{
+		return 'jenkins.conf';
+	}
+}


### PR DESCRIPTION
The original `StopTheLineJenkins` `HookAction` was using deprecated code and configuration framework. This change updates the git hook to use the new configuration framework and the recently updated `Jenkins\Job` class.